### PR TITLE
cd with no args returns you to the initial dag

### DIFF
--- a/src/commands/cd.js
+++ b/src/commands/cd.js
@@ -2,8 +2,8 @@ const Path = require('path')
 const debug = require('debug')('ipld-explorer-cli:commands:cd')
 const isIpfs = require('is-ipfs')
 
-module.exports = async function cd ({ ipfs, wd, spinner }, path) {
-  path = path || wd
+async function cd ({ ipfs, wd, spinner }, path) {
+  path = path || await getInitialPath(ipfs)
 
   if (isIpfs.cid(path)) {
     path = `/ipfs/${path}`
@@ -21,3 +21,17 @@ module.exports = async function cd ({ ipfs, wd, spinner }, path) {
   debug(path)
   return { out: path, ctx: { wd: path } }
 }
+
+async function getInitialPath (ipfs) {
+  let hash
+  // TODO: remove once js-ipfs supports MFS
+  if (ipfs.files.stat) {
+    hash = (await ipfs.files.stat('/')).hash
+  } else {
+    hash = 'QmfGBRT6BbWJd7yUc2uYdaUZJBbnEFvTqehPFoSMQ6wgdr'
+  }
+  return `/ipfs/${hash}`
+}
+
+module.exports = cd
+module.exports.getInitialPath = getInitialPath

--- a/src/index.js
+++ b/src/index.js
@@ -57,16 +57,8 @@ module.exports = async function () {
 
   async function getInitialCtx () {
     const ipfs = IpfsApi()
-    let hash
-
-    // TODO: remove once js-ipfs supports MFS
-    if (ipfs.files.stat) {
-      hash = (await ipfs.files.stat('/')).hash
-    } else {
-      hash = 'QmfGBRT6BbWJd7yUc2uYdaUZJBbnEFvTqehPFoSMQ6wgdr'
-    }
-
-    return { ipfs, wd: `/ipfs/${hash}` }
+    const wd = await Commands.cd.getInitialPath(ipfs)
+    return { ipfs, wd }
   }
 
   async function getAutoCompleteList ({ ipfs, wd }) {


### PR DESCRIPTION
Return the user to the initial path if they call `cd` with no args.

Pulls `getInitialPath` into the `cd` command where it can be exported and reused in `getInitialCtx`.