### PR TITLE
docs: add information on using it with JS-IPFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Type "help" then <Enter> for a list of commands
 ? >
 ```
 
+If you use JS-IPFS, make sure you set the `apiAddr` accordingly:
+
+```sh
+? > config set apiAddr /ip4/127.0.0.1/tcp/5002
+```
+
 ### Commands
 
 #### `cd [path]` (alias `get`)


### PR DESCRIPTION
The JS-IPFS daemon runs on a different port (5002) than Go-IPFS (5001),
hence ipld-explorer needs to be configured to use port 5002.